### PR TITLE
Place quotes around CB_PASSWORD

### DIFF
--- a/eks/cb-operator-guide/files/sh/backup-with-periodic-merge.sh
+++ b/eks/cb-operator-guide/files/sh/backup-with-periodic-merge.sh
@@ -81,7 +81,7 @@ type $CBBACKUPMGR >/dev/null 2>&1 || {
 ############## STEP 1 : BACKUP
 echo "---------------------------------------------------------"
 echo  BEGIN STEP 1: BACKUP : "$(date)"
-CMD="${CBBACKUPMGR} backup  --archive $ARCHIVE --repo $REPO --cluster couchbase://${CLUSTER} --username $CB_USERNAME --password $CB_PASSWORD --threads ${THREADS}"
+CMD="${CBBACKUPMGR} backup  --archive $ARCHIVE --repo $REPO --cluster couchbase://${CLUSTER} --username $CB_USERNAME --password '$CB_PASSWORD' --threads ${THREADS}"
 echo -e "Running backup... \n Command:  $CMD"
 eval "$CMD"
 


### PR DESCRIPTION
This will address characters such as `)` ans `(` when placed in the password.

**Error**

```bash
 Command:  cbbackupmgr backup  --archive /backups --repo couchbase --cluster couchbase://localhost --username admin --password K)8r=^ --threads 2
./backup-with-periodic-merge.sh: eval: line 86: syntax error near unexpected token `)'
```
**After fix**

```bash
Running backup...
 Command:  cbbackupmgr backup  --archive /backups --repo couchbase --cluster couchbase://localhost --username admin --password 'K)8r=^' --threads 2

Backing up to 2020-02-19T09_39_23.909732226Z
Copied all data in 22.012333527s (Avg. 35.05KB/Sec)                                                                                                              171 items / 771.05KB
```